### PR TITLE
FIX: 메인-방문한 관광지 영역 수정

### DIFF
--- a/SODAM/Sources/View/HomeView.swift
+++ b/SODAM/Sources/View/HomeView.swift
@@ -102,6 +102,7 @@ struct HomeView: View {
                             .padding(5)
                     }
                 }
+                .padding(.bottom, 30) // 탭바에 가려지는 영역 때문에 추가
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
@@ -239,7 +240,7 @@ struct TodaySpotView: View {
                     }
                 }
             )
-        }else {
+        } else {
             ProgressView()
         }
     }

--- a/SODAM/Sources/ViewModel/HomeViewModel.swift
+++ b/SODAM/Sources/ViewModel/HomeViewModel.swift
@@ -4,15 +4,17 @@ import CoreLocation
 
 @MainActor
 class HomeViewModel: ObservableObject {
-    @Query var visitedSpots: [PlaceItem]
+    
     @Environment(\.modelContext) private var modelContext
-//    @Published var visitedSpots: [PlaceItem]
+    
     @Published var isLoading: Bool = true
     @Published var playerState: Bool = false
     @Published var todaySpot: DetailModel? = nil
+    @Published var visitedSpots: [PlaceItem] = []
     
     init() {
-        fetchTodayStory()
+        fetchTodayStory()   // 오늘의 이야기
+        fetchVisitedPlace() // 방문한 관광지
     }
     
     let columns = [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]
@@ -67,4 +69,15 @@ class HomeViewModel: ObservableObject {
         }
     }
     
+    // 방문한 관광지 가져오기
+    func fetchVisitedPlace() {
+        do {
+            visitedSpots = try DataManager.shared.fetchPlaceItems()
+            print("개수 : \(visitedSpots.count)")
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
 }
+


### PR DESCRIPTION
- DataManager에 있는 SwiftData 메소드 활용해서 데이터 불러올 수 있도록 수정
- 메인에서 방문한 관광지가 있을 경우에 탭바에 콘텐츠가 가려져서 VStack에 padding 30 추가